### PR TITLE
Fix blockchain height fork for reward which caused sync issue

### DIFF
--- a/consensus/ethash/consensus.go
+++ b/consensus/ethash/consensus.go
@@ -731,7 +731,7 @@ func accumulateRewards(config *params.ChainConfig, state *state.StateDB, header 
 		blockReward = big.NewInt(0.6e+18)
 		masternodeReward = big.NewInt(0.8e+18)
 		developmentReward = big.NewInt(0.5e+18)
-	} else if (header.Number.Int64() >= 8000000) && (header.Number.Int64() < 8130000) {
+	} else if (header.Number.Int64() >= 8000000) && (header.Number.Int64() < 8150000) {
 		blockReward = ConstantinopleBlockReward
 		masternodeReward = big.NewInt(0.65e+18)
 		developmentReward = big.NewInt(0.35e+18)


### PR DESCRIPTION
Fixing default reward between block 8,130,000 and block 8,150,000