### PR TITLE
fix invalid difficulty when syncing from scratch

### DIFF
--- a/consensus/ethash/consensus.go
+++ b/consensus/ethash/consensus.go
@@ -341,9 +341,9 @@ func CalcDifficulty(config *params.ChainConfig, time uint64, parent *types.Heade
 	case config.IsLondon(next):
 		return calcDifficultyEip3554(time, parent)
 	case config.IsMuirGlacier(next):
-		if next.Cmp(big.NewInt(8150000) > 0 {
+		if next.Cmp(big.NewInt(8150000)) > 0 {
 	                params.MinimumDifficulty = big.NewInt(200000000000)
-		} else if next.Cmp(big.NewInt(8250000) > 0 {
+		} else if next.Cmp(big.NewInt(8250000)) > 0 {
 	                params.MinimumDifficulty = big.NewInt(5000000000)
 		} else {
 			// this fixes invalid difficulty when syncing


### PR DESCRIPTION
Patch invalid difficulty when syncing from scratch
Correct difficulty from block between 8_000_000 and 8_150_000.

***Need testing before merge***

TODO:
- fix "invalid merkle root" at block 7813054 when syncing in archive mode